### PR TITLE
Removed // eslint children warning for markdown

### DIFF
--- a/src/components/BlogMenu.tsx
+++ b/src/components/BlogMenu.tsx
@@ -31,11 +31,9 @@ const BlogMenu = ({ markdownContent }: { markdownContent: string }) => {
 
   return (
     <Pane padding="20px" className="blog-menu">
-      <ReactMarkdown
-        rehypePlugins={[[rehypeSlug, { prefix: 'toc-' }]]}
-        // eslint-disable-next-line react/no-children-prop
-        children={toc}
-      />
+      <ReactMarkdown rehypePlugins={[[rehypeSlug, { prefix: 'toc-' }]]}>
+        {toc}
+      </ReactMarkdown>
     </Pane>
   );
 };

--- a/src/pages/blog/blogs/Sora/Sora.tsx
+++ b/src/pages/blog/blogs/Sora/Sora.tsx
@@ -34,9 +34,9 @@ const Sora = () => {
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex, rehypeRaw, rehypeHighlight, rehypeSlug]}
         components={components}
-        // eslint-disable-next-line react/no-children-prop
-        children={markdownContent}
-      />
+      >
+        {markdownContent}
+      </ReactMarkdown>
     </div>
   );
 };

--- a/src/pages/blog/blogs/Transformers/Transformers.tsx
+++ b/src/pages/blog/blogs/Transformers/Transformers.tsx
@@ -47,9 +47,9 @@ const Transformers = () => {
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex, rehypeRaw, rehypeHighlight, rehypeSlug]}
         components={components}
-        // eslint-disable-next-line react/no-children-prop
-        children={markdownContent}
-      />
+      >
+        {markdownContent}
+      </ReactMarkdown>
     </div>
   );
 };

--- a/src/pages/notes/CSO2/cso2.md
+++ b/src/pages/notes/CSO2/cso2.md
@@ -1635,18 +1635,3 @@ The `execute` stage typically _**forwards**_ the result to the `issue` stage of 
 ### **References**
 
 This note is based on [CS 3130 Spring 2024](https://www.cs.virginia.edu/~cr4bd/3130/S2024/) by Charles Reiss, used under CC BY-NC-SA 4.0.
-
-TODO:
-
-- Exceptions + context switche:
-  - exceptions vs context switches
-  - sending signal to procese vs thread
-- Process:
-  - count the` number of processes
-  - Fork children tree, pid stuff.
-  - waitpid, `wait, waitpid options
-
-Cache:
-
-- tag index offset
-- use index to access set

--- a/src/pages/notes/CSO2/cso2.md
+++ b/src/pages/notes/CSO2/cso2.md
@@ -1636,10 +1636,17 @@ The `execute` stage typically _**forwards**_ the result to the `issue` stage of 
 
 This note is based on [CS 3130 Spring 2024](https://www.cs.virginia.edu/~cr4bd/3130/S2024/) by Charles Reiss, used under CC BY-NC-SA 4.0.
 
-$$
+TODO:
 
+- Exceptions + context switche:
+  - exceptions vs context switches
+  - sending signal to procese vs thread
+- Process:
+  - count the` number of processes
+  - Fork children tree, pid stuff.
+  - waitpid, `wait, waitpid options
 
-$$
+Cache:
 
-$$
-$$
+- tag index offset
+- use index to access set

--- a/src/pages/notes/CSO2/cso2.tsx
+++ b/src/pages/notes/CSO2/cso2.tsx
@@ -70,9 +70,9 @@ const CSO2 = () => {
               remarkPlugins={[remarkGfm, remarkMath]}
               rehypePlugins={[rehypeKatex, rehypeRaw, rehypeHighlight, rehypeSlug]}
               components={components}
-              // eslint-disable-next-line react/no-children-prop
-              children={markdownContent}
-            />
+            >
+              {markdownContent}
+            </ReactMarkdown>
           </Pane>
         </Pane>
       </Pane>


### PR DESCRIPTION
Directly moved child markdown string as child of <ReactMarkDown>.